### PR TITLE
Fix parsing of dashed line for bencher

### DIFF
--- a/src/icon_exclaim_perf_tools/log_import.py
+++ b/src/icon_exclaim_perf_tools/log_import.py
@@ -23,7 +23,7 @@ class LineCursor:
 
     def skip(self, pattern: str, strip=True):
         line = self.current_line()
-        while re.match(r"mo_.*:.*", line.strip()):
+        while re.match(r"^mo_.*:.*", line.strip()):
             next(self)
             line = self.current_line()
             continue
@@ -177,7 +177,7 @@ def import_timer_report(
     # skip header
     header_dash_pattern = re.compile("([-]+)".join(["(\\s+)"] * (len(columns.values())+1)))
     line_iterator.skip("")
-    while re.match(r"mo_.*:.*", line_iterator.current_line().strip()):
+    while re.match(r"^mo_.*:.*", line_iterator.current_line().strip()):
         next(line_iterator)
     header_dash_line = line_iterator.current_line()
     line_iterator.skip(header_dash_pattern, strip=False)
@@ -193,7 +193,7 @@ def import_timer_report(
     last_level_stack = [-1]
     last_entry_stack = [None]
     for i, line in enumerate(line_iterator):
-        if re.match(r"mo_.*:.*", line.strip()):
+        if re.match(r"^mo_.*:.*", line.strip()):
             continue
         if re.match(r"-+", line.strip()):  # last line consists of just dashes
             break
@@ -267,7 +267,7 @@ def import_subdomains(
          enumerate(header_dash_pattern.search(header_dash_line).groups())]))
 
     for line in line_iterator:
-        if re.match(r"mo_.*:.*", line.strip()):
+        if re.match(r"^mo_.*:.*", line.strip()):
             continue
         if not line.strip():  # last line consists of just dashes
             break

--- a/src/icon_exclaim_perf_tools/log_import.py
+++ b/src/icon_exclaim_perf_tools/log_import.py
@@ -301,6 +301,9 @@ def extract_build_mode_from_executable(line: str) -> ModelRunMode:
     if not match:
         return None
     run_mode: str = match.group(1)
+    if run_mode not in ["acc", "gpu2py", "cpu2py", "cpu"]:
+        print(f"Warning: Could novt determine run mode from executable line, unrecognized build folder name \"{match.group(0)}\" in \"{match.string}\"")
+        return None
     if run_mode == "acc":
         return ModelRunMode.OPENACC
     else:
@@ -339,7 +342,7 @@ def import_model_run_log(
             mode = extract_build_mode_from_executable(line)
             if mode is not None:
                 model_run.mode = mode
-        elif (match := re.search(r'\bBUILD_(GPU2PY|ACC|CPU2PY|CPU)\b', line)):
+        elif (match := re.search(r'This executable was built for:  BUILD_(GPU2PY|ACC|CPU2PY|CPU)\b', line)):
             model_run.mode = ModelRunMode[match.group(1).upper()]
     line_iterator.rewind()
 

--- a/src/icon_exclaim_perf_tools/log_import.py
+++ b/src/icon_exclaim_perf_tools/log_import.py
@@ -177,8 +177,7 @@ def import_timer_report(
     # skip header
     header_dash_pattern = re.compile("([-]+)".join(["(\\s+)"] * (len(columns.values())+1)))
     line_iterator.skip("")
-    # Make sure we assign to the head_dash_line a line that contains dashes
-    while not re.match(r"-+", line_iterator.current_line().strip()):
+    while re.match(r"mo_.*:.*", line_iterator.current_line().strip()):
         next(line_iterator)
     header_dash_line = line_iterator.current_line()
     line_iterator.skip(header_dash_pattern, strip=False)

--- a/src/icon_exclaim_perf_tools/log_import.py
+++ b/src/icon_exclaim_perf_tools/log_import.py
@@ -177,6 +177,9 @@ def import_timer_report(
     # skip header
     header_dash_pattern = re.compile("([-]+)".join(["(\\s+)"] * (len(columns.values())+1)))
     line_iterator.skip("")
+    # Make sure we assign to the head_dash_line a line that contains dashes
+    while not re.match(r"-+", line_iterator.current_line().strip()):
+        next(line_iterator)
     header_dash_line = line_iterator.current_line()
     line_iterator.skip(header_dash_pattern, strip=False)
     line_iterator.skip(re.compile("\\s+".join([re.escape(column) for column in columns.values()])))


### PR DESCRIPTION
See failure in https://cicd-ext-mw.cscs.ch/ci/job/result/7129647185505644/70285748/12349876193?iid=391. The problem was:
```
...
 
 Timer report
 
 mo_alloc_patches:destruct_comm_patterns: start
 ------------------------   -------   ------------   ------------   ------------   -------------   -------------   -------------    
 name                       # calls   t_min          t_avg          t_max          total min (s)   total max (s)   total avg (s)    
 ------------------------   -------   ------------   ------------   ------------   -------------   -------------   -------------    
 
 wrt_output                 12         0.00000191s    2.91461708s    3.49439597s         34.975          34.975          34.975     
 model_init                 1          0.79272604s    0.79272604s    0.79272604s          0.793           0.793           0.793     
  L compute_domain_decomp   1          0.79265213s    0.79265213s    0.79265213s          0.793           0.793           0.793     
 -------------------------------------------------------------------------------------------------------------------------------   
 ...
 ```