### PR TITLE
Support python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
 description = 'Repository containing performance data of icon exclaim. '
 name = 'icon_exclaim_perf_tools'
 readme = {file = 'README.md', content-type = 'text/markdown'}
-requires-python = '>=3.10'
+requires-python = '>=3.9'
 version = '0.0'
 
 [project.scripts]

--- a/src/icon_exclaim_perf_tools/log_import.py
+++ b/src/icon_exclaim_perf_tools/log_import.py
@@ -198,7 +198,12 @@ def import_timer_report(
         values = [*column_pattern.search(line).groups()]
         level = values[0].index("L") if "L" in values[0] else 0
         values[0] = values[0].replace("L", "")
-        entry_data = {k: v.strip() for k, v in zip(columns.keys(), values, strict=True)}
+        if len(columns.keys()) != len(values):
+            raise ValueError(f"Number of columns in timer report line does not match expected number of columns.\n"
+                             f"Line: `{line}`\n"
+                             f"Expected columns: {list(columns.keys())}\n"
+                             f"Extracted values: {values}")
+        entry_data = {k: v.strip() for k, v in zip(columns.keys(), values)}
         entry_data["time_min"] = convert_to_seconds_icon(entry_data["time_min"])
         entry_data["time_max"] = convert_to_seconds_icon(entry_data["time_max"])
         entry_data["time_avg"] = convert_to_seconds_icon(entry_data["time_avg"])


### PR DESCRIPTION
I tried on my laptop with Python 3.9 and installation and running worked. I hope it also works on the CI with Python 3.9 as well.
It enables using the tools with icon-exclaim CI: https://github.com/C2SM/icon-exclaim/pull/399